### PR TITLE
Added link helpers from framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
     "autoload": {
         "psr-4": {
             "Illuminate\\Html\\": ""
-        }
+        },
+        "files": [
+            "helpers.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,69 @@
+<?php
+
+if ( ! function_exists('link_to'))
+{
+    /**
+     * Generate a HTML link.
+     *
+     * @param  string  $url
+     * @param  string  $title
+     * @param  array   $attributes
+     * @param  bool    $secure
+     * @return string
+     */
+    function link_to($url, $title = null, $attributes = array(), $secure = null)
+    {
+        return app('html')->link($url, $title, $attributes, $secure);
+    }
+}
+
+if ( ! function_exists('link_to_asset'))
+{
+    /**
+     * Generate a HTML link to an asset.
+     *
+     * @param  string  $url
+     * @param  string  $title
+     * @param  array   $attributes
+     * @param  bool    $secure
+     * @return string
+     */
+    function link_to_asset($url, $title = null, $attributes = array(), $secure = null)
+    {
+        return app('html')->linkAsset($url, $title, $attributes, $secure);
+    }
+}
+
+if ( ! function_exists('link_to_route'))
+{
+    /**
+     * Generate a HTML link to a named route.
+     *
+     * @param  string  $name
+     * @param  string  $title
+     * @param  array   $parameters
+     * @param  array   $attributes
+     * @return string
+     */
+    function link_to_route($name, $title = null, $parameters = array(), $attributes = array())
+    {
+        return app('html')->linkRoute($name, $title, $parameters, $attributes);
+    }
+}
+
+if ( ! function_exists('link_to_action'))
+{
+    /**
+     * Generate a HTML link to a controller action.
+     *
+     * @param  string  $action
+     * @param  string  $title
+     * @param  array   $parameters
+     * @param  array   $attributes
+     * @return string
+     */
+    function link_to_action($action, $title = null, $parameters = array(), $attributes = array())
+    {
+        return app('html')->linkAction($action, $title, $parameters, $attributes);
+    }
+}


### PR DESCRIPTION
This adds the link helpers that were removed from the framework repo in pull request https://github.com/laravel/framework/pull/5694.
