### PR TITLE
Creating missing container aliases from "registerCoreContainerAliases" method

### DIFF
--- a/HtmlServiceProvider.php
+++ b/HtmlServiceProvider.php
@@ -21,6 +21,9 @@ class HtmlServiceProvider extends ServiceProvider {
 		$this->registerHtmlBuilder();
 
 		$this->registerFormBuilder();
+
+		$this->app->alias('html', 'Illuminate\Html\HtmlBuilder');
+		$this->app->alias('form', 'Illuminate\Html\FormBuilder');
 	}
 
 	/**
@@ -30,7 +33,6 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHtmlBuilder()
 	{
-		$this->app->alias('html', 'Illuminate\Html\HtmlBuilder');
 		$this->app->bindShared('html', function($app)
 		{
 			return new HtmlBuilder($app['url']);
@@ -44,7 +46,6 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerFormBuilder()
 	{
-		$this->app->alias('form', 'Illuminate\Html\FormBuilder');
 		$this->app->bindShared('form', function($app)
 		{
 			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());


### PR DESCRIPTION
Right now container aliases from almost all core components are registered in the `registerCoreContainerAliases` method. This immediately creates problems when some of components stop being part of core, e.g. `Html` in Laravel 5.0.

I propose for each component's service provider to register it's own container aliases.

Related issue: rcrowe/TwigBridge#150
