### PR TITLE
Expose all classes, that "HtmlServiceProvider" is responsible for

### DIFF
--- a/HtmlServiceProvider.php
+++ b/HtmlServiceProvider.php
@@ -61,7 +61,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('html', 'form');
+		return array('html', 'form', 'Illuminate\Html\HtmlBuilder', 'Illuminate\Html\FormBuilder');
 	}
 
 }


### PR DESCRIPTION
Because this service provider is differed we need to expose fact, that it's responsible for handling `HtmlBuilder` and `FormBuilder` classes. Without this the corresponding `form` and `html` aliases won't be registered before they are used during Container dependency resolution.

This is 2nd PR that together with #12 will fix missing `Html` component alias problem.
