### PR TITLE
Get token from $sessionStore when token is empty

### DIFF
--- a/FormBuilder.php
+++ b/FormBuilder.php
@@ -178,7 +178,9 @@ class FormBuilder {
 	 */
 	public function token()
 	{
-		return $this->hidden('_token', $this->csrfToken);
+		$token = ! empty($this->csrfToken) ? $this->csrfToken : $this->session->getToken();
+
+		return $this->hidden('_token', $token);
 	}
 
 	/**


### PR DESCRIPTION
FIxed a bug when using csrf on latest Laravel 5 build.

```
[2014-10-16 14:27:25] production.ERROR: exception 'Illuminate\Session\TokenMismatchException' in /Users/crynobone/Sites/sandbox/app/Http/Middleware/CsrfMiddleware.php:24
Stack trace:
#0 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): App\Http\Middleware\CsrfMiddleware->handle(Object(Illuminate\Http\Request), Object(Closure))
#1 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/View/Middleware/ErrorBinder.php(55): Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#2 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): Illuminate\View\Middleware\ErrorBinder->handle(Object(Illuminate\Http\Request), Object(Closure))
#3 /Users/crynobone/Sites/sandbox/storage/framework/compiled.php(8884): Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#4 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): Illuminate\Session\Middleware\Writer->handle(Object(Illuminate\Http\Request), Object(Closure))
#5 /Users/crynobone/Sites/sandbox/storage/framework/compiled.php(8850): Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#6 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): Illuminate\Session\Middleware\Reader->handle(Object(Illuminate\Http\Request), Object(Closure))
#7 /Users/crynobone/Sites/sandbox/storage/framework/compiled.php(9453): Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#8 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): Illuminate\Cookie\Middleware\Queue->handle(Object(Illuminate\Http\Request), Object(Closure))
#9 /Users/crynobone/Sites/sandbox/storage/framework/compiled.php(9401): Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#10 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): Illuminate\Cookie\Middleware\Guard->handle(Object(Illuminate\Http\Request), Object(Closure))
#11 /Users/crynobone/Sites/sandbox/app/Http/Middleware/GuestMiddleware.php(40): Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#12 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(73): App\Http\Middleware\MaintenanceMiddleware->handle(Object(Illuminate\Http\Request), Object(Closure))
#13 [internal function]: Illuminate\Routing\Stack\Stack->Illuminate\Routing\Stack\{closure}(Object(Illuminate\Http\Request))
#14 /Users/crynobone/Sites/sandbox/vendor/laravel/framework/src/Illuminate/Routing/Stack/Stack.php(59): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#15 /Users/crynobone/Sites/sandbox/storage/framework/compiled.php(983): Illuminate\Routing\Stack\Stack->run(Object(Illuminate\Http\Request))
#16 /Users/crynobone/Sites/sandbox/storage/framework/compiled.php(964): Illuminate\Foundation\Application->handleRequest(Object(Illuminate\Http\Request))
#17 /Users/crynobone/Sites/sandbox/public/index.php(49): Illuminate\Foundation\Application->run()
#18 {main} [] []
```
