### PR TITLE
Handle label value '0' properly

### DIFF
--- a/FormBuilder.php
+++ b/FormBuilder.php
@@ -211,7 +211,7 @@ class FormBuilder {
 	 */
 	protected function formatLabel($name, $value)
 	{
-		return $value ?: ucwords(str_replace('_', ' ', $name));
+		return (string)$value != '' ? $value : ucwords(str_replace('_', ' ', $name));
 	}
 
 	/**


### PR DESCRIPTION
Created to resolve laravel/framework#6376 where the use is not able to make labels with the text being a zero, such as:
`{{ Form::label("nps","0") }}`
The code improves on this by casting the value to a string and checking if it is an empty string or not when deciding between showing the actual value or generating a string from the field name.
