### PR TITLE
Direct to the Laravel Collective fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+The HTML component has been removed from the Laravel framework and is not maintained anymore.
+
+However, the [Laravel Collective](http://laravelcollective.com/) has created a fork: [LaravelCollective/html](https://github.com/LaravelCollective/html).


### PR DESCRIPTION
The very least (and presumably only) thing to do is to point out there is a maintained fork of the component.
