### PR TITLE
singleton() function is a replacement for bindShared() function  in laravel 5.2.*

### DIFF
--- a/HtmlServiceProvider.php
+++ b/HtmlServiceProvider.php
@@ -33,7 +33,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHtmlBuilder()
 	{
-		$this->app->bindShared('html', function($app)
+		$this->app->singleton('html', function($app)
 		{
 			return new HtmlBuilder($app['url']);
 		});
@@ -46,7 +46,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerFormBuilder()
 	{
-		$this->app->bindShared('form', function($app)
+		$this->app->singleton('form', function($app)
 		{
 			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
 


### PR DESCRIPTION
singleton() function is used in the laravel 5.2.\* which is a replacement for bindShared() function. The bindShared() method failed since it is not available is Illuminate\Foundation\Application class
