### PR TITLE
Changed the bindShared() call to singleton() call

### DIFF
--- a/HtmlServiceProvider.php
+++ b/HtmlServiceProvider.php
@@ -33,7 +33,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHtmlBuilder()
 	{
-		$this->app->bindShared('html', function($app)
+		$this->app->singleton('html', function($app)
 		{
 			return new HtmlBuilder($app['url']);
 		});
@@ -46,7 +46,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerFormBuilder()
 	{
-		$this->app->bindShared('form', function($app)
+		$this->app->singleton('form', function($app)
 		{
 			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,13 @@
 {
-    "name": "illuminate/html",
+    "name": "bobkosse/html",
     "license": "MIT",
     "authors": [
         {
             "name": "Taylor Otwell",
             "email": "taylorotwell@gmail.com"
+        }, {
+            "name": "Bob Kosse",
+            "email": "b.kosse@dareconcepts.nl"
         }
     ],
     "require": {


### PR DESCRIPTION
As mentioned on https://laracasts.com/discuss/channels/laravel/call-to-undefined-method-illuminatefoundationapplicationbindshared the $app->bindShared() is replaced with $app->singleton().

This changes makes the Form and HTML facade working with Laravel 5.2 again.
