### PR TITLE
Solves problem with Laravel version 5.2

### DIFF
--- a/HtmlServiceProvider.php
+++ b/HtmlServiceProvider.php
@@ -33,7 +33,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHtmlBuilder()
 	{
-		$this->app->bindShared('html', function($app)
+		$this->app->singleton('html', function($app)
 		{
 			return new HtmlBuilder($app['url']);
 		});
@@ -46,7 +46,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerFormBuilder()
 	{
-		$this->app->bindShared('form', function($app)
+		$this->app->singleton('form', function($app)
 		{
 			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
 


### PR DESCRIPTION
The following message appears when Illuminate\Html\HtmlServiceProvider::class is added to providers array.

[Symfony\Component\Debug\Exception\FatalErrorException]
Call to undefined method Illuminate\Foundation\Application::bindShared()

The solution is to rename the method bindShared to singleton.

I found the solution in:
https://laracasts.com/discuss/channels/laravel/call-to-undefined-method-illuminatefoundationapplicationbindshared
