### PR TITLE
Make compatible for 5.4 bindShared() to singleton(), getToken() to to…

### DIFF
--- a/HtmlServiceProvider.php
+++ b/HtmlServiceProvider.php
@@ -33,7 +33,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHtmlBuilder()
 	{
-		$this->app->bindShared('html', function($app)
+		$this->app->singleton('html', function($app)
 		{
 			return new HtmlBuilder($app['url']);
 		});
@@ -46,9 +46,9 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	protected function registerFormBuilder()
 	{
-		$this->app->bindShared('form', function($app)
+		$this->app->singleton('form', function($app)
 		{
-			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
+			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->token());
 
 			return $form->setSessionStore($app['session.store']);
 		});


### PR DESCRIPTION
…ken()

- [ ] Make compatible for 5.2 and above `bindShared()` to `singleton()`
- [ ] Make compatible for 5.4 `getToken` to `token()`